### PR TITLE
Set Resources on Container object

### DIFF
--- a/pkg/apis/travisci/v1alpha1/workercluster_types.go
+++ b/pkg/apis/travisci/v1alpha1/workercluster_types.go
@@ -41,6 +41,9 @@ type WorkerSpec struct {
 	// The pull policy for the worker image.
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
+	// Request/limit resources for the worker container.
+	Resources v1.ResourceRequirements `json:"resources,omitempty"`
+
 	// A list of environment variables to set on the worker container.
 	// The worker cluster will add more variables to this list when creating the deployment.
 	Env []v1.EnvVar `json:"env,omitempty"`

--- a/pkg/controller/workercluster/workercluster_controller.go
+++ b/pkg/controller/workercluster/workercluster_controller.go
@@ -248,6 +248,7 @@ func newDeploymentForCluster(cluster *travisciv1alpha1.WorkerCluster) *appsv1.De
 		ImagePullPolicy: s.ImagePullPolicy,
 		Env:             configureEnvironment(s.Env),
 		EnvFrom:         s.EnvFrom,
+		Resources:       s.Resources,
 		LivenessProbe: &corev1.Probe{
 			InitialDelaySeconds: 120,
 			Handler: corev1.Handler{


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The pods currently don't request or limit their resources, this caused havoc as too many workers got scheduled on the same node. With the lack of requesting resources, GKE didn't know it should autoscale, so we got stuck on 3 nodes.

## What approach did you choose and why?
This adds the 'corev1.Resources' object, which allow us to set the limits and requested resources. By setting this to an acceptable value, GKE should know when a node has reached its capacity and autoscale the cluster.

## How can you test this?
I'll be running this on staging, more specifically: I'll run it with and without the resources defined on staging to observe the worker-operator behavior.

## What feedback would you like, if any?
If you have experience with worker-operator or operators in general, reach out.

